### PR TITLE
Make Azure Functions public; update config and routing

### DIFF
--- a/Tlumacov.OfficialBoard.Api/Functions.cs
+++ b/Tlumacov.OfficialBoard.Api/Functions.cs
@@ -20,7 +20,7 @@ public class Functions(
 {
     [Function("RegisterSubscriber")]
     public async Task<HttpResponseData> RegisterSubscriber(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "register-subscriber")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "register-subscriber")] HttpRequestData req)
     {
         var logger = loggerFactory.CreateLogger("RegisterSubscriber");
         var connector = new SshConnector();
@@ -66,7 +66,7 @@ public class Functions(
 
     [Function("VerifyToken")]
     public async Task<HttpResponseData> VerifyToken(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "subscription/verify-token")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "subscription/verify-token")] HttpRequestData req)
     {
         var logger = loggerFactory.CreateLogger("VerifyToken");
         var connector = new SshConnector();
@@ -122,7 +122,7 @@ public class Functions(
 
     [Function("Unsubscribe")]
     public async Task<HttpResponseData> Unsubscribe(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "subscription/unsubscribe")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "subscription/unsubscribe")] HttpRequestData req)
     {
         var logger = loggerFactory.CreateLogger("Unsubscribe");
         var connector = new SshConnector();

--- a/Tlumacov.OfficialBoard.Shared/TokenService.cs
+++ b/Tlumacov.OfficialBoard.Shared/TokenService.cs
@@ -47,7 +47,7 @@ public class TokenService(IOptions<EmailOptions> options) : ITokenService
 
     public byte[] GetSecretKey()
     {
-        string secretKey = _options.TokenSecret ?? "YourVerySecretKeyForTokenGeneration-ShouldBeAtLeast32CharsLong";
+        string secretKey = _options.TokenSecret;
         return Encoding.UTF8.GetBytes(secretKey);
     }
 

--- a/Tlumacov.OfficialBoard.Web/staticwebapp.config.json
+++ b/Tlumacov.OfficialBoard.Web/staticwebapp.config.json
@@ -1,0 +1,17 @@
+﻿{
+  "routes": [
+    {
+      "route": "/api/register-subscriber",
+      "methods": [ "POST", "OPTIONS" ],
+      "allowedRoles": [ "anonymous" ]
+    },
+    {
+      "route": "/api/*",
+      "allowedRoles": [ "authenticated" ]
+    }
+  ],
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [ "/api/*" ]
+  }
+}


### PR DESCRIPTION
Make Azure Functions public; update config and routing

Changed `AuthorizationLevel` for `RegisterSubscriber`,
`VerifyToken`, and `Unsubscribe` to `Anonymous`, making
them publicly accessible. Removed default fallback for
`TokenSecret` in `TokenService` to enforce explicit
configuration. Added `staticwebapp.config.json` to define
routing and role-based access control for Static Web App,
including anonymous access to `/api/register-subscriber`
and authenticated access to other `/api/*` routes.