### PR TITLE
Enhance CORS headers for API routes

### DIFF
--- a/Tlumacov.OfficialBoard.Web/staticwebapp.config.json
+++ b/Tlumacov.OfficialBoard.Web/staticwebapp.config.json
@@ -6,7 +6,8 @@
       "allowedRoles": [ "anonymous" ],
       "headers": {
         "Access-Control-Allow-Origin": "https://www.tlumacov.cz",
-        "Access-Control-Allow-Methods": "POST, OPTIONS"
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With"
       }
     },
     {
@@ -15,7 +16,8 @@
       "allowedRoles": [ "anonymous" ],
       "headers": {
         "Access-Control-Allow-Origin": "${CLIENT_ORIGIN}",
-        "Access-Control-Allow-Methods": "POST, OPTIONS"
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With"
       }
     }
   ],


### PR DESCRIPTION
Enhance CORS headers for API routes

Added `Access-Control-Allow-Headers` to the CORS configuration for `/api/register-subscriber` and `/api/*` routes. This allows the headers `Content-Type`, `Authorization`, and `X-Requested-With` in cross-origin requests, improving support for APIs requiring custom headers.